### PR TITLE
Fixed the issue where infowindows re-appear on zooming in or out.

### DIFF
--- a/app/assets/js/main.js
+++ b/app/assets/js/main.js
@@ -7,7 +7,8 @@ var map,
     layerToggle,
     mapLayers,
     carto,
-    sql;
+    sql,
+    infowindows;
 
     // mapboxgl.accessToken = 'pk.eyJ1IjoibGJsb2siLCJhIjoiY2o3djQ2ODd4MnVjMjJwbjBxZWZtZDB2ZiJ9.4gctlFUX_n0BzOAwbuL2aw';
     // const map = new mapboxgl.Map({
@@ -113,10 +114,11 @@ app.map = (function(w, d, L, $) {
         }
 
         /* when using the layerSource object, create infowindows like so: */
-        cdb.vis.Vis.addInfowindow(map,layer.getSubLayer(0),["cartodb_id"], {infowindowTemplate: $('#riskscore_infowindow').html()});
-        cdb.vis.Vis.addInfowindow(map,layer.getSubLayer(1),["cartodb_id"], {infowindowTemplate: $('#rentregscore_infowindow').html()});
-        cdb.vis.Vis.addInfowindow(map,layer.getSubLayer(2),["cartodb_id"], {infowindowTemplate: $('#dobscore_infowindow').html()});
-        cdb.vis.Vis.addInfowindow(map,layer.getSubLayer(3),["cartodb_id"], {infowindowTemplate: $('#dofscore_infowindow').html()});
+        infowindows = [];
+        infowindows[0] = cdb.vis.Vis.addInfowindow(map,layer.getSubLayer(0),["cartodb_id"], {infowindowTemplate: $('#riskscore_infowindow').html()});
+        infowindows[1] = cdb.vis.Vis.addInfowindow(map,layer.getSubLayer(1),["cartodb_id"], {infowindowTemplate: $('#rentregscore_infowindow').html()});
+        infowindows[2] = cdb.vis.Vis.addInfowindow(map,layer.getSubLayer(2),["cartodb_id"], {infowindowTemplate: $('#dobscore_infowindow').html()});
+        infowindows[3] = cdb.vis.Vis.addInfowindow(map,layer.getSubLayer(3),["cartodb_id"], {infowindowTemplate: $('#dofscore_infowindow').html()});
 
 
         // very sloppy example tooltip creation
@@ -281,8 +283,9 @@ app.map = (function(w, d, L, $) {
       mapLayers[1].hide();
       mapLayers[2].hide();
       mapLayers[3].hide();
-      $('.cartodb-infowindow').css('visibility', 'hidden');
-      // console.log(mapLayers[0])
+      for (let index = 0; index < infowindows.length; index++) {
+        infowindows[index].model.set("visibility", !1);
+      }
     }
 
     $('.radio1').click(function(e) {


### PR DESCRIPTION
Hi @lblok ! 

I was able to work out the problem where multiple infowindows were showing up when togging between layers and then zooming in or out. I created a array variable called `infowindows` to manipulate them, and in the function `hideAllLayers`, I wrote a simple for loop that sets the visibility of all of the infowindows to false. I looked through the carto.js codebase to figure out how they close infowindow, and that was their strategy. 

From here, all you need to do is merge my pull request into master and then you should be able to close this branch. 

Cheers!
JD